### PR TITLE
Added the Deploy stage to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,10 @@ node('thor-build') {
 		}
 	    }
 	    stage('Deploy') {
-		//
+		unstash 'scm'
+		dir ('build') {
+		    sh 'make install'
+		}
 	    }
 	}
     }


### PR DESCRIPTION
The install step was unintentionally removed from the Jenkinsfile. The Deploy stage was updated to descend into the build directory and call 'make install'
