### PR TITLE
v0.2.3 reserve memory for new chain segement in blockchain.h

### DIFF
--- a/src/consensus/blockchain.h
+++ b/src/consensus/blockchain.h
@@ -62,6 +62,7 @@ public:
     if (chain_size_ % segment_capacity_ == 0) {
       new_seg = true;
       std::vector<FinalBlockSharedPtr> seg;
+      seg.reserve(segment_capacity_);
       seg.push_back(block);
       chain_.push_back(seg);
     } else {


### PR DESCRIPTION
This may help avoid memory issues by avoiding reallocations.  It not, we may have uncovered another concurrency issue in the business logic.