### PR TITLE
Call lock() properly on the UTXPool lock object to resolve GH-54

### DIFF
--- a/src/concurrency/ConsensusController.cpp
+++ b/src/concurrency/ConsensusController.cpp
@@ -42,7 +42,7 @@ void ConsensusController::consensusCallback(DevvMessageUniquePtr ptr) {
         break;
 
       case eMessageType::PROPOSAL_BLOCK:LOG_DEBUG << "ConsensusController()::consensusCallback(): PROPOSAL_BLOCK";
-        utx_pool_.get_transaction_creation_manager().set_keys(&keys_);
+        utx_pool_.getTransactionCreationManager().set_keys(&keys_);
         proposal_block_cb_(std::move(ptr),
                                              context_,
                                              keys_,

--- a/src/concurrency/ValidatorController.cpp
+++ b/src/concurrency/ValidatorController.cpp
@@ -85,6 +85,7 @@ void ValidatorController::validatorCallback(DevvMessageUniquePtr ptr) {
   // Acquire the proposal lock, but don't lock it yet (we don't want to block
   // on a lock here)
   auto proposal_lock = utx_pool_.acquireProposalPermissionLock();
+  proposal_lock->lock();
 
   // Try to acquire the lock, break out if the lock is in use
   if (!proposal_lock->try_lock()) {

--- a/src/concurrency/ValidatorController.cpp
+++ b/src/concurrency/ValidatorController.cpp
@@ -85,7 +85,6 @@ void ValidatorController::validatorCallback(DevvMessageUniquePtr ptr) {
   // Acquire the proposal lock, but don't lock it yet (we don't want to block
   // on a lock here)
   auto proposal_lock = utx_pool_.acquireProposalPermissionLock();
-  proposal_lock->lock();
 
   // Try to acquire the lock, break out if the lock is in use
   if (!proposal_lock->try_lock()) {

--- a/src/concurrency/ValidatorController.cpp
+++ b/src/concurrency/ValidatorController.cpp
@@ -54,6 +54,7 @@ ValidatorController::~ValidatorController() {
 void ValidatorController::validatorCallback(DevvMessageUniquePtr ptr) {
   LOG_DEBUG << "ValidatorController::validatorCallback()";
   auto full_lock = utx_pool_.acquireFullLock();
+  full_lock->lock();
 
   //Do not remove lock_guard, function may use atomic<bool> as concurrency signal
   std::lock_guard<std::mutex> guard(mutex_);

--- a/src/consensus/UnrecordedTransactionPool.h
+++ b/src/consensus/UnrecordedTransactionPool.h
@@ -232,7 +232,7 @@ class UnrecordedTransactionPool {
  /**
   *  @return the tool to create Transactions in parallel
   */
-  TransactionCreationManager& get_transaction_creation_manager() {
+  TransactionCreationManager& getTransactionCreationManager() {
     return(tcm_);
   }
 

--- a/src/consensus/UnrecordedTransactionPool.h
+++ b/src/consensus/UnrecordedTransactionPool.h
@@ -284,10 +284,6 @@ class UnrecordedTransactionPool {
   }
 
   /**
-   * Get a mutex to coordinate shared access to local
-   * data
-   */
-  /**
    * Acquire full lock to coordinate shared access to local
    * data.
    * @note This is viewed as a temporary fix. It hurts performance
@@ -299,6 +295,11 @@ class UnrecordedTransactionPool {
     return full_lock_->clone();
   }
 
+  /**
+   * Change the FullLock lock type. Primarily used for testing and execution
+   * in a single-threaded environment
+   * @param lock
+   */
   void setFullLock(std::unique_ptr<ILock> lock) {
     full_lock_.swap(lock);
   }
@@ -337,8 +338,6 @@ class UnrecordedTransactionPool {
 
   /// Temporary/test mutex to lock all callbacks and force serial
   /// execution
-  //mutable std::mutex full_mutex_;
-
   mutable std::unique_ptr<ILock> full_lock_ = std::make_unique<UniqueLock>();
 
   /**

--- a/src/consensus/tier2_message_handlers.cpp
+++ b/src/consensus/tier2_message_handlers.cpp
@@ -62,6 +62,7 @@ bool HandleFinalBlock(DevvMessageUniquePtr ptr,
   }
 
   auto full_lock = utx_pool.acquireFullLock();
+  full_lock->lock();
 
   // Profiling
   MTR_SCOPE_FUNC();
@@ -131,6 +132,7 @@ bool HandleProposalBlock(DevvMessageUniquePtr ptr,
   }
 
   auto full_lock = utx_pool.acquireFullLock();
+  full_lock->lock();
 
   MTR_SCOPE_FUNC();
 
@@ -181,6 +183,7 @@ bool HandleValidationBlock(DevvMessageUniquePtr ptr,
                            UnrecordedTransactionPool& utx_pool,
                            std::function<void(DevvMessageUniquePtr)> callback) {
   auto full_lock = utx_pool.acquireFullLock();
+  full_lock->lock();
 
   if (ptr->message_type != eMessageType::VALID) {
     throw std::runtime_error("HandleValidationBlock: message != eMessageType::VALID");

--- a/src/consensus/tier2_message_handlers.cpp
+++ b/src/consensus/tier2_message_handlers.cpp
@@ -78,6 +78,8 @@ bool HandleFinalBlock(DevvMessageUniquePtr ptr,
 
   LOG_DEBUG << "HandleFinalBlock(): acquiring proposal_lock";
   auto proposal_lock =  utx_pool.acquireProposalPermissionLock();
+  proposal_lock->lock();
+
   LOG_DEBUG << *proposal_lock << " HandleFinalBlock(): proposal_lock acquired and locked";
 
   auto top_block = std::make_shared<FinalBlock>(utx_pool.finalizeRemoteBlock(

--- a/src/consensus/tier2_message_handlers.cpp
+++ b/src/consensus/tier2_message_handlers.cpp
@@ -139,7 +139,7 @@ bool HandleProposalBlock(DevvMessageUniquePtr ptr,
   ChainState prior = final_chain.getHighestChainState();
   InputBuffer buffer(ptr->data);
   ProposedBlock to_validate(ProposedBlock::Create(buffer, prior, keys
-      , utx_pool.get_transaction_creation_manager()));
+      , utx_pool.getTransactionCreationManager()));
 
   // Block if a new FinalBlock is still processing
   if (utx_pool.isNewFinalBlockProcessing()) {

--- a/src/gtest/consensus_test.cpp
+++ b/src/gtest/consensus_test.cpp
@@ -545,8 +545,8 @@ class UnrecordedTransactionPoolTest : public ::testing::Test {
       keys_.addNodeKeyPair(kNODE_ADDRs.at(i), kNODE_KEYs.at(i), "password");
     }
     utx_pool_ptr_ = std::make_unique<UnrecordedTransactionPool>(chain_state_, eAppMode::T2, 100);
-    //auto no_lock = std::make_unique<NoOpLock>();
-    //utx_pool_ptr_->setFullLock(std::move(no_lock));
+    auto no_lock = std::make_unique<NoOpLock>();
+    utx_pool_ptr_->setFullLock(std::move(no_lock));
   }
 
   ~UnrecordedTransactionPoolTest() override = default;

--- a/src/gtest/consensus_test.cpp
+++ b/src/gtest/consensus_test.cpp
@@ -245,7 +245,8 @@ class TestTransactionHandler : public TestHandler {
     EXPECT_EQ(ProposedBlock::isNullProposal(proposal), false);
 
     InputBuffer buffer(proposal);
-    ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, *keys_, utx_pool_ptr_->get_transaction_creation_manager()));
+    ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, *keys_,
+                                                    utx_pool_ptr_->getTransactionCreationManager()));
 
     EXPECT_EQ(to_validate.getVersion(), 0);
 
@@ -650,7 +651,7 @@ TEST_F(UnrecordedTransactionPoolTest, validate_0) {
   ProposedBlock to_validate(ProposedBlock::Create(buffer,
                                                   chain_state_,
                                                   keys_,
-                                                  utx_pool_ptr_->get_transaction_creation_manager()));
+                                                  utx_pool_ptr_->getTransactionCreationManager()));
   EXPECT_EQ(to_validate.getVersion(), 0);
 
   auto valid = to_validate.validate(keys_);
@@ -674,7 +675,8 @@ TEST_F(UnrecordedTransactionPoolTest, validate_1) {
   EXPECT_EQ(ProposedBlock::isNullProposal(proposal), false);
 
   InputBuffer buffer(proposal);
-  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->get_transaction_creation_manager()));
+  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_,
+                                                  utx_pool_ptr_->getTransactionCreationManager()));
   auto valid = to_validate.validate(keys_);
   size_t node_num = 2;
   auto sign = to_validate.signBlock(keys_, node_num);
@@ -701,7 +703,8 @@ TEST_F(UnrecordedTransactionPoolTest, finalize_0) {
   EXPECT_EQ(ProposedBlock::isNullProposal(proposal), false);
 
   InputBuffer buffer(proposal);
-  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->get_transaction_creation_manager()));
+  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_,
+                                                  utx_pool_ptr_->getTransactionCreationManager()));
   auto valid = to_validate.validate(keys_);
   size_t node_num = 2;
   auto sign = to_validate.signBlock(keys_, node_num);
@@ -737,7 +740,8 @@ TEST_F(UnrecordedTransactionPoolTest, finalize_inn_tx) {
   EXPECT_EQ(ProposedBlock::isNullProposal(proposal), false);
 
   InputBuffer buffer(proposal);
-  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->get_transaction_creation_manager()));
+  ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_,
+                                                  utx_pool_ptr_->getTransactionCreationManager()));
 
   EXPECT_EQ(to_validate.getVersion(), 0);
 
@@ -788,7 +792,8 @@ auto proposal = createTestProposal();
 EXPECT_EQ(ProposedBlock::isNullProposal(proposal), false);
 
 InputBuffer buffer(proposal);
-ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->get_transaction_creation_manager()));
+ProposedBlock to_validate(ProposedBlock::Create(buffer, chain_state_, keys_,
+                                                utx_pool_ptr_->getTransactionCreationManager()));
 auto valid = to_validate.validate(keys_);
 size_t node_num = 2;
 auto sign = to_validate.signBlock(keys_, node_num);
@@ -825,7 +830,7 @@ TEST_F(UnrecordedTransactionPoolTest, DISABLED_proposal_stream_0) {
   auto proposal = createTestProposal();
 
   InputBuffer buffer(proposal);
-  auto proposal2 = ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->get_transaction_creation_manager());
+  auto proposal2 = ProposedBlock::Create(buffer, chain_state_, keys_, utx_pool_ptr_->getTransactionCreationManager());
 
   EXPECT_EQ(proposal, proposal2.getCanonical());
 }


### PR DESCRIPTION
An interface change was made to the UniqueLock() between v0.2.2 and v0.2.3 and subsequently in v0.2.3, after a lock is acquired it needs to be locked explicitly.