### PR TITLE
Update CMake to install a static lib and cmake config files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,13 +11,12 @@ if(WITH_JAVA_SUPPORT)
   include_directories(${JAVA_HOME}/include)
   include_directories(${JAVA_HOME}/include/linux)
 else()
-  project("Devv" C CXX)
+  project(Devv C CXX)
 endif()
 
-set (CMAKE_CXX_STANDARD 14)
-set (CMAKE_CXX_STANDARD_REQUIRED ON)
-set (Devv_VERSION_MAJOR 0)
-set (Devv_VERSION_MINOR 3)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(Devv_VERSION 0.3.0)
 
 enable_testing()
 
@@ -192,16 +191,8 @@ set(devv_dep_libs
         ${PQXX}
         )
 
-add_library(devv-core SHARED ${devv_objects})
+add_library(devv-core STATIC ${devv_objects})
 target_link_libraries(devv-core ${devv_dep_libs})
-
-install(TARGETS devv-core
-        LIBRARY DESTINATION lib)
-
-# Install header files
-foreach(submodule ${devv_submodules})
-    install(DIRECTORY ${submodule} DESTINATION include FILES_MATCHING PATTERN "*.h")
-endforeach()
 
 macro(add_test_executable executable source_file)
     add_executable(${executable} ${source_file} ${devv_objects})
@@ -230,6 +221,73 @@ if(WITH_JAVA_SUPPORT)
     target_link_libraries(devvjni ${devv_all_libs})
 endif()
 
+############ Config
+# Introduce variables:
+# * CMAKE_INSTALL_LIBDIR
+# * CMAKE_INSTALL_BINDIR
+# * CMAKE_INSTALL_INCLUDEDIR
+include(GNUInstallDirs)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib*/cmake/<PROJECT-NAME>
+#   * <prefix>/lib*/
+#   * <prefix>/include/
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+        "${version_config}" VERSION ${Devv_VERSION} COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+        "cmake/Config.cmake.in"
+        "${project_config}"
+        INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Install Targets
+install(TARGETS devv-core
+        EXPORT "${TARGETS_EXPORT_NAME}"
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+# Install header files
+foreach(submodule ${devv_submodules})
+    install(DIRECTORY ${submodule} DESTINATION include FILES_MATCHING PATTERN "*.h")
+endforeach()
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooConfig.cmake
+#   * <prefix>/lib/cmake/Foo/FooConfigVersion.cmake
+install(
+        FILES "${project_config}" "${version_config}"
+        DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/Foo/FooTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
 
 #
 # executables

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (Devv_VERSION_MAJOR 0)
-set (Devv_VERSION_MINOR 2)
+set (Devv_VERSION_MINOR 3)
 
 enable_testing()
 
@@ -63,19 +63,20 @@ if(WITH_JAVA_SUPPORT)
 endif()
 
 # Dummy target that triggers python protobuf generation
-add_custom_target(myTarget ALL DEPENDS ${PROTO_PY})
+add_custom_target(pbuf-dummy-target ALL DEPENDS ${PROTO_PY})
 
-file(GLOB_RECURSE dcSources "*.cpp")
-file(GLOB_RECURSE dcHeaders "*.h*")
-set (dcInclude "")
-foreach (_headerFile ${dcHeaders})
-  get_filename_component(_dir ${_headerFile} PATH)
-  list (APPEND dcInclude ${_dir})
-endforeach()
-list(REMOVE_DUPLICATES dcInclude)
+# Create empty variable to hold object files
+set(devv_objects)
+
+# Helper functino to register Devv libraries
+function(register_devv_lib)
+    add_library(${ARGV})
+    set(devv_objects ${devv_objects} $<TARGET_OBJECTS:${ARGV0}> PARENT_SCOPE)
+    set_property(TARGET ${ARGV0} PROPERTY POSITION_INDEPENDENT_CODE ON)
+endfunction()
 
 # Protobuf generated library
-ADD_LIBRARY(devvpbuf devv.pb.h devv.pb.cc)
+register_devv_lib(devvpbuf OBJECT devv.pb.h devv.pb.cc)
 set_source_files_properties(devv.pb.h devv.pb.cc PROPERTIES GENERATED TRUE)
 
 find_package(Git)
@@ -114,48 +115,35 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/common/devv_version.cpp.in" "${CMAKE
 list(APPEND generated_SRC "${CMAKE_CURRENT_BINARY_DIR}/devv_version.cpp" devv_version.h)
 
 # Build the common module objects
-file(GLOB common_SRC
-    "common/*.cpp" "common/*.c" ${generated_SRC}
-)
-add_library(common ${common_SRC})
+file(GLOB common_SRC "common/*.cpp" "common/*.c" ${generated_SRC})
+register_devv_lib(common OBJECT ${common_SRC})
 
 # Build the concurrency module objects
-file(GLOB concurrency_SRC
-    "concurrency/*.cpp"
-)
-add_library(concurrency ${concurrency_SRC})
+file(GLOB concurrency_SRC "concurrency/*.cpp")
+register_devv_lib(concurrency OBJECT ${concurrency_SRC})
 
 # Build the consensus module objects
-file(GLOB consensus_SRC
-    "consensus/*.cpp"
-)
-add_library(consensus ${consensus_SRC})
+file(GLOB consensus_SRC "consensus/*.cpp")
+register_devv_lib(consensus OBJECT ${consensus_SRC})
 
 # Build the io module objects
-file(GLOB io_SRC
-    "io/*.cpp"
-)
-add_library(io ${io_SRC})
+file(GLOB io_SRC "io/*.cpp")
+register_devv_lib(io OBJECT ${io_SRC})
 add_dependencies(io devvpbuf)
 
 # Build the pbuf module objects
-file(GLOB pbuf_SRC
-        "pbuf/*.cpp"
-)
-add_library(pbuf ${pbuf_SRC})
+file(GLOB pbuf_SRC "pbuf/*.cpp")
+register_devv_lib(pbuf OBJECT ${pbuf_SRC})
 add_dependencies(pbuf devvpbuf)
 
 # Build the primitives module objects
-file(GLOB primitives_SRC
-    "primitives/*.cpp"
-)
-add_library(primitives ${primitives_SRC})
+file(GLOB primitives_SRC "primitives/*.cpp")
+register_devv_lib(primitives OBJECT ${primitives_SRC})
 
 # Add BlockchainModule.cpp
-add_library(modules modules/BlockchainModule.cpp)
+file(GLOB modules_SRC "modules/*.cpp")
+register_devv_lib(modules OBJECT ${modules_SRC})
 add_dependencies(modules devvpbuf)
-
-set(devv_core_libs modules common concurrency consensus io pbuf primitives devvpbuf)
 
 option(WITH_THREAD_TESTING "Enable thread testing" OFF)
 
@@ -184,8 +172,7 @@ set(CONFIGURED_ONCE TRUE CACHE INTERNAL
     "A flag showing that CMake has configured at least once.")
 
 # Convenience variable containing all linker libs
-set(devv_all_libs
-        ${devv_core_libs}
+set(devv_dep_libs
         ${ZMQ}
         ${PROTOBUF_LIBRARY}
         ${OPENSSL_LIBRARIES}
@@ -194,13 +181,15 @@ set(devv_all_libs
         ${PQXX}
         )
 
-#
-# devv executable
-#
-add_executable(devv-validator devv-validator.cpp)
-target_link_libraries (devv-validator ${devv_all_libs})
-target_include_directories(devv-validator PRIVATE ${dcInclude})
-install (TARGETS devv-validator DESTINATION bin)
+add_library(devv-core SHARED ${devv_objects})
+target_link_libraries(devv-core ${devv_dep_libs})
+install (TARGETS devv-core DESTINATION lib)
+
+macro(add_devv_executable executable source_file)
+    add_executable(${executable} ${source_file} ${devv_objects})
+    target_link_libraries(${executable} ${devv_dep_libs})
+    install(TARGETS ${executable} DESTINATION bin)
+endmacro()
 
 #
 # JNI Library
@@ -213,187 +202,38 @@ if(WITH_JAVA_SUPPORT)
     )
     add_library(devvjni SHARED
       ${devvjni_SRC}
-      ${dcInclude}
     )
     install (TARGETS devvjni DESTINATION lib)
     target_link_libraries(devvjni ${devv_all_libs})
 endif()
 
-#
-# devv-scanner
-#
-add_executable(devv-scanner devv-scanner.cpp ${dcInclude})
-target_link_libraries (devv-scanner ${devv_all_libs})
-target_include_directories(devv-scanner PRIVATE ${dcInclude})
-install (TARGETS devv-scanner DESTINATION bin)
 
 #
-# devv-key
+# executables
 #
-add_executable(devv-key devv-key.cpp ${dcInclude} ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries (devv-key ${devv_all_libs})
-target_include_directories(devv-key PRIVATE ${dcInclude})
-install (TARGETS devv-key DESTINATION bin)
-
-#
-# devv-sign
-#
-add_executable(devv-sign devv-sign.cpp ${dcInclude} ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries (devv-sign ${devv_all_libs})
-target_include_directories(devv-sign PRIVATE ${dcInclude})
-install (TARGETS devv-sign DESTINATION bin)
-
-#
-# devv-annnouncer
-#
-add_executable(devv-announcer devv-announcer.cpp ${dcInclude} ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries (devv-announcer ${devv_all_libs})
-target_include_directories(devv-announcer PRIVATE ${dcInclude})
-install (TARGETS devv-announcer DESTINATION bin)
-
-#
-# devv-query
-#
-add_executable(devv-query devv-query.cpp ${dcInclude})
-target_link_libraries (devv-query ${devv_all_libs})
-target_include_directories(devv-query PRIVATE ${dcInclude})
-install (TARGETS devv-query DESTINATION bin)
-
-#
-# devv-psql
-#
-add_executable(devv-psql devv-psql.cpp ${dcInclude})
-target_link_libraries (devv-psql ${devv_all_libs})
-target_include_directories(devv-psql PRIVATE ${dcInclude})
-install (TARGETS devv-psql DESTINATION bin)
-
-#
-# reset-db 
-#
-
-add_executable(reset-db reset-db.cpp ${dcInclude})
-target_link_libraries (reset-db ${devv_all_libs})
-target_include_directories(reset-db PRIVATE ${dcInclude})
-install (TARGETS reset-db DESTINATION bin)
-
-#
-# circuit-gen
-#
-add_executable(circuit-gen circuit-gen.cpp ${dcInclude})
-target_link_libraries (circuit-gen ${devv_all_libs})
-target_include_directories(circuit-gen PRIVATE ${dcInclude})
-install (TARGETS circuit-gen DESTINATION bin)
-
-#
-# laminar-gen
-#
-add_executable(laminar-gen laminar-gen.cpp ${dcInclude})
-target_link_libraries (laminar-gen ${devv_all_libs})
-target_include_directories(laminar-gen PRIVATE ${dcInclude})
-install (TARGETS laminar-gen DESTINATION bin)
-
-#
-# turbulent-gen
-#
-add_executable(turbulent-gen turbulent-gen.cpp ${dcInclude})
-target_link_libraries (turbulent-gen ${devv_all_libs})
-target_include_directories(turbulent-gen PRIVATE ${dcInclude})
-install (TARGETS turbulent-gen DESTINATION bin)
-
-#
-# devv-verify
-#
-add_executable(devv-verify devv-verify.cpp ${dcInclude})
-target_link_libraries (devv-verify ${devv_all_libs})
-target_include_directories(devv-verify PRIVATE ${dcInclude})
-install (TARGETS devv-verify DESTINATION bin)
+add_devv_executable(devv-validator devv-validator.cpp)
+add_devv_executable(devv-scanner devv-scanner.cpp)
+add_devv_executable(devv-key devv-key.cpp)
+add_devv_executable(devv-sign devv-sign.cpp)
+add_devv_executable(devv-announcer devv-announcer.cpp)
+add_devv_executable(devv-query devv-query.cpp)
+add_devv_executable(devv-psql devv-psql.cpp)
+add_devv_executable(reset-db reset-db.cpp)
+add_devv_executable(circuit-gen circuit-gen.cpp)
+add_devv_executable(laminar-gen laminar-gen.cpp)
+add_devv_executable(turbulent-gen turbulent-gen.cpp)
+add_devv_executable(devv-verify devv-verify.cpp)
 
 #
 # i/o Tests
 #
-add_executable(ring_queue_test
-  tests/concurrency/ring_queue_test.cpp
-  )
-
-target_link_libraries(ring_queue_test
-  ${devv_core_libs}
-  ${OPENSSL_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${Boost_LIBRARIES}
-  )
-
-install (TARGETS ring_queue_test DESTINATION bin)
-
-# # # devv_spsc_queue_test
-add_executable(devv_spsc_queue_test
-  tests/concurrency/devv_spsc_queue_test.cpp
-  )
-
-target_link_libraries(devv_spsc_queue_test
-  ${devv_core_libs}
-  ${OPENSSL_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${Boost_LIBRARIES}
-  )
-
-install (TARGETS devv_spsc_queue_test DESTINATION bin)
-
-# # # boost_spsc_test
-add_executable(boost_spsc_test
-  tests/concurrency/boost_spsc_test.cpp
-  )
-
-target_link_libraries(boost_spsc_test
-  ${devv_core_libs}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${Boost_LIBRARIES}
-  )
-
-install (TARGETS boost_spsc_test DESTINATION bin)
-
-# # # io_server_test
-add_executable(io_server_test
-  tests/io/transaction_server.cpp
-  )
-
-target_link_libraries(io_server_test
-  ${devv_core_libs}
-  ${ZMQ}
-  ${OPENSSL_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${Boost_LIBRARIES}
-  )
-
-# # # io_client_test
-add_executable(io_client_test
-  tests/io/transaction_client.cpp
-  )
-
-target_link_libraries(io_client_test
-  ${devv_core_libs}
-  ${ZMQ}
-  ${OPENSSL_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${Boost_LIBRARIES}
-  )
-
-# # # zmq_envelope_publisher
-add_executable(zmq_envelope_publisher
-  tests/io/zmq_envelope_publisher.cpp
-  )
-
-target_link_libraries(zmq_envelope_publisher
-  ${ZMQ}
-  )
-
-# # # zmq_envelope_subscriber
-add_executable(zmq_envelope_subscriber
-  tests/io/zmq_envelope_subscriber.cpp
-  )
-
-target_link_libraries(zmq_envelope_subscriber
-  ${ZMQ}
-  )
+add_devv_executable(ring_queue_test tests/concurrency/ring_queue_test.cpp)
+add_devv_executable(devv_spsc_queue_test tests/concurrency/devv_spsc_queue_test.cpp)
+add_devv_executable(boost_spsc_test tests/concurrency/boost_spsc_test.cpp)
+add_devv_executable(io_server_test tests/io/transaction_server.cpp)
+add_devv_executable(io_client_test tests/io/transaction_client.cpp)
+add_devv_executable(zmq_envelope_publisher tests/io/zmq_envelope_publisher.cpp)
+add_devv_executable(zmq_envelope_subscriber tests/io/zmq_envelope_subscriber.cpp)
 
 ######### gtest ##########
 include(${CMAKE_CURRENT_SOURCE_DIR}/gtest/CMakeLists.txt)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,18 @@ execute_process(COMMAND
 # generate version.cc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/common/devv_version.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/devv_version.cpp" @ONLY)
 
-list(APPEND generated_SRC "${CMAKE_CURRENT_BINARY_DIR}/devv_version.cpp" devv_version.h)
+list(APPEND generated_SRC "${CMAKE_CURRENT_BINARY_DIR}/devv_version.cpp" "common/devv_version.h")
+
+# This list is used to install header files
+set(devv_submodules
+        common
+        concurrency
+        consensus
+        io
+        pbuf
+        primitives
+        modules
+        oracles)
 
 # Build the common module objects
 file(GLOB common_SRC "common/*.cpp" "common/*.c" ${generated_SRC})
@@ -183,7 +194,19 @@ set(devv_dep_libs
 
 add_library(devv-core SHARED ${devv_objects})
 target_link_libraries(devv-core ${devv_dep_libs})
-install (TARGETS devv-core DESTINATION lib)
+
+install(TARGETS devv-core
+        LIBRARY DESTINATION lib)
+
+# Install header files
+foreach(submodule ${devv_submodules})
+    install(DIRECTORY ${submodule} DESTINATION include FILES_MATCHING PATTERN "*.h")
+endforeach()
+
+macro(add_test_executable executable source_file)
+    add_executable(${executable} ${source_file} ${devv_objects})
+    target_link_libraries(${executable} ${devv_dep_libs})
+endmacro()
 
 macro(add_devv_executable executable source_file)
     add_executable(${executable} ${source_file} ${devv_objects})
@@ -227,13 +250,13 @@ add_devv_executable(devv-verify devv-verify.cpp)
 #
 # i/o Tests
 #
-add_devv_executable(ring_queue_test tests/concurrency/ring_queue_test.cpp)
-add_devv_executable(devv_spsc_queue_test tests/concurrency/devv_spsc_queue_test.cpp)
-add_devv_executable(boost_spsc_test tests/concurrency/boost_spsc_test.cpp)
-add_devv_executable(io_server_test tests/io/transaction_server.cpp)
-add_devv_executable(io_client_test tests/io/transaction_client.cpp)
-add_devv_executable(zmq_envelope_publisher tests/io/zmq_envelope_publisher.cpp)
-add_devv_executable(zmq_envelope_subscriber tests/io/zmq_envelope_subscriber.cpp)
+add_test_executable(ring_queue_test tests/concurrency/ring_queue_test.cpp)
+add_test_executable(devv_spsc_queue_test tests/concurrency/devv_spsc_queue_test.cpp)
+add_test_executable(boost_spsc_test tests/concurrency/boost_spsc_test.cpp)
+add_test_executable(io_server_test tests/io/transaction_server.cpp)
+add_test_executable(io_client_test tests/io/transaction_client.cpp)
+add_test_executable(zmq_envelope_publisher tests/io/zmq_envelope_publisher.cpp)
+add_test_executable(zmq_envelope_subscriber tests/io/zmq_envelope_subscriber.cpp)
 
 ######### gtest ##########
 include(${CMAKE_CURRENT_SOURCE_DIR}/gtest/CMakeLists.txt)

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")
+
+set(Devv_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include)
+set(Devv_LIBRARY ${PACKAGE_PREFIX_DIR}/lib/libdevv-core.a)

--- a/src/gtest/CMakeLists.txt
+++ b/src/gtest/CMakeLists.txt
@@ -12,39 +12,30 @@ find_package(GTest REQUIRED)
 #find_package(GMock REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
+macro(add_gtest executable source_file)
+    add_executable(${executable} ${source_file} ${devv_objects})
+    target_link_libraries(${executable} ${GTEST_BOTH_LIBRARIES} ${devv_dep_libs})
+    add_test(NAME ${executable} COMMAND ${executable})
+endmacro()
+
 # Primitive data type tests
-add_executable(primitives_test gtest/primitives_test.cpp)
-target_link_libraries(primitives_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
+add_gtest(primitives_test gtest/primitives_test.cpp)
 
 # unit tests for concurrency algorithms
-add_executable(concurrency_test gtest/concurrency_test.cpp)
-target_link_libraries(concurrency_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
+add_gtest(concurrency_test gtest/concurrency_test.cpp)
 
 # unit tests for consensus algorithms
-add_executable(consensus_test gtest/consensus_test.cpp)
-target_link_libraries(consensus_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
+add_gtest(consensus_test gtest/consensus_test.cpp)
 
 # ossladapter tests
-add_executable(ossladapter_test gtest/ossladapter_test.cpp)
-target_link_libraries(ossladapter_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
+add_gtest(ossladapter_test gtest/ossladapter_test.cpp)
 
 # protocol buffer tests
-add_executable(pbuf_test gtest/pbuf_test.cpp)
-target_link_libraries(pbuf_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
-add_dependencies(pbuf_test devvpbuf)
+#add_gtest(pbuf_test gtest/pbuf_test.cpp)
+#add_dependencies(pbuf_test devvpbuf)
 
 # blockchain tests
-add_executable(blockchain_test gtest/blockchain_test.cpp)
-target_link_libraries(blockchain_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
+add_gtest(blockchain_test gtest/blockchain_test.cpp)
 
 # blockchainmodule tests
-add_executable(blockchainmodule_test gtest/blockchainmodule_test.cpp)
-target_link_libraries(blockchainmodule_test ${GTEST_BOTH_LIBRARIES} ${devv_all_libs})
-
-add_test(NAME primitives_test COMMAND primitives_test)
-add_test(NAME concurrency_test COMMAND concurrency_test)
-add_test(NAME consensus_test COMMAND consensus_test)
-add_test(NAME ossladapter_test COMMAND ossladapter_test)
-#add_test(NAME pbuf_test COMMAND pbuf_test)
-add_test(NAME blockchain_test COMMAND blockchain_test)
-add_test(NAME blockchainmodule_test COMMAND blockchainmodule_test)
+add_gtest(blockchainmodule_test gtest/blockchainmodule_test.cpp)


### PR DESCRIPTION
To use Devv-Core as a library for third-party applications, the build was updated to install a static library, the header files and the cmake project config files